### PR TITLE
Define pyDes requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ PACKAGES = [
 REQUIREMENTS = [
     'Django>=1.11',
     'django-payments>=0.12.3',
+    'pyDes>=2.0.0',
 ]
 
 setup(


### PR DESCRIPTION
It defines `pyDes` as an install requirement, ensuring that all needed dependencies are process at installation time.

Fix #3 pyDes dependency is not satisfied
