### PR TITLE
Use `get_base_url` for success and failure urls composition

### DIFF
--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -36,7 +36,7 @@ from django.http import HttpResponse
 from django.shortcuts import redirect
 
 from payments.forms import PaymentForm
-from payments.core import BasicProvider
+from payments.core import BasicProvider, get_base_url, urljoin
 
 from django import forms
 
@@ -96,8 +96,8 @@ class RedsysProvider(BasicProvider):
             "DS_MERCHANT_TRANSACTIONTYPE": '0',
             "DS_MERCHANT_TERMINAL": self.terminal,
             "DS_MERCHANT_MERCHANTURL": self.get_return_url(payment),
-            "DS_MERCHANT_URLOK": payment.get_success_url(),
-            "DS_MERCHANT_URLKO": payment.get_failure_url(),
+            "DS_MERCHANT_URLOK": urljoin(get_base_url(), payment.get_success_url()),
+            "DS_MERCHANT_URLKO": urljoin(get_base_url(), payment.get_failure_url()),
             "Ds_Merchant_ConsumerLanguage": '002',
         }
         json_data = json.dumps(merchant_data)

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -27,11 +27,6 @@ import pyDes
 
 from codecs import encode
 
-try:
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin
-
 from django.http import HttpResponse
 from django.shortcuts import redirect
 


### PR DESCRIPTION
As done for the other django_payment providers, use `django_payments.core.get_base_url` method to compose final success and failure URLs.

This will ensure that the same backend will be used for the `DS_MERCHANT_URL*` without the need to hardcode / compute the base_url at Payment model level (at `Payment.get_success_url` and/or `Payment.get_failure_url` methods)

Please remember to update the pypi release!