### PR TITLE
Add new merchant parameter: ds_merchant_directpayment

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ A Redsys~~Sermepa~~ payment gateway backend for [django-payments](https://github
   * Sandbox endpoint is default. Production endpoint is 'https://sis.redsys.es'
 * order_number_prefix (default:'0000'): Payment PK is suffixed to this to create Redsys order number
 * signature_version (default:'HMAC_SHA256_V1'): Only supported signature type.
+* ds_merchant_directpayment (default: "TRUE"): "TRUE" or "FALSE"
+
 
 
 ## settings.py

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A Redsys~~Sermepa~~ payment gateway backend for [django-payments](https://github
   * Sandbox endpoint is default. Production endpoint is 'https://sis.redsys.es'
 * order_number_prefix (default:'0000'): Payment PK is suffixed to this to create Redsys order number
 * signature_version (default:'HMAC_SHA256_V1'): Only supported signature type.
-* direct_payment (default: True): True or False
+* direct_payment (default: False): True or False
   * redsys (spanish) related doc: https://pagosonline.redsys.es/oneclick.html
 
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A Redsys~~Sermepa~~ payment gateway backend for [django-payments](https://github
   * Sandbox endpoint is default. Production endpoint is 'https://sis.redsys.es'
 * order_number_prefix (default:'0000'): Payment PK is suffixed to this to create Redsys order number
 * signature_version (default:'HMAC_SHA256_V1'): Only supported signature type.
-* direct_payment (default: "TRUE"): "TRUE" or "FALSE"
+* direct_payment (default: True): True or False
   * redsys (spanish) related doc: https://pagosonline.redsys.es/oneclick.html
 
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ A Redsys~~Sermepa~~ payment gateway backend for [django-payments](https://github
   * Sandbox endpoint is default. Production endpoint is 'https://sis.redsys.es'
 * order_number_prefix (default:'0000'): Payment PK is suffixed to this to create Redsys order number
 * signature_version (default:'HMAC_SHA256_V1'): Only supported signature type.
-* ds_merchant_directpayment (default: "TRUE"): "TRUE" or "FALSE"
+* direct_payment (default: "TRUE"): "TRUE" or "FALSE"
+  * redsys (spanish) related doc: https://pagosonline.redsys.es/oneclick.html
 
 
 

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -78,7 +78,7 @@ class RedsysProvider(BasicProvider):
         self.terminal = kwargs.pop('terminal')
         self.shared_secret = kwargs.pop('shared_secret')
         self.currency = kwargs.pop('currency', '978')
-        self.direct_payment = str(kwargs.pop('direct_payment', True)).upper()
+        self.direct_payment = str(kwargs.pop('direct_payment', False)).upper()
 
         # Get provided endpoint base domain or REDSYS.pruebas env
         self.endpoint = urljoin(

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -78,7 +78,7 @@ class RedsysProvider(BasicProvider):
         self.terminal = kwargs.pop('terminal')
         self.shared_secret = kwargs.pop('shared_secret')
         self.currency = kwargs.pop('currency', '978')
-        self.ds_merchant_directpayment = kwargs.pop('ds_merchant_directpayment', 'TRUE')
+        self.ds_merchant_directpayment = kwargs.pop('ds_merchant_directpayment', 'TRUE').upper()
 
         # Get provided endpoint base domain or REDSYS.pruebas env
         self.endpoint = urljoin(

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -78,7 +78,7 @@ class RedsysProvider(BasicProvider):
         self.terminal = kwargs.pop('terminal')
         self.shared_secret = kwargs.pop('shared_secret')
         self.currency = kwargs.pop('currency', '978')
-        self.ds_merchant_directpayment = kwargs.pop('ds_merchant_directpayment', 'TRUE').upper()
+        self.direct_payment = kwargs.pop('direct_payment', 'TRUE').upper()
 
         # Get provided endpoint base domain or REDSYS.pruebas env
         self.endpoint = urljoin(
@@ -117,7 +117,7 @@ class RedsysProvider(BasicProvider):
             "DS_MERCHANT_AMOUNT": amount,
             "DS_MERCHANT_ORDER": order_number,
             "DS_MERCHANT_MERCHANTCODE": self.merchant_code,
-            "DS_MERCHANT_DIRECTPAYMENT": self.ds_merchant_directpayment,
+            "DS_MERCHANT_DIRECTPAYMENT": self.direct_payment,
             "DS_MERCHANT_CURRENCY": self.currency,
             "DS_MERCHANT_TRANSACTIONTYPE": '0',
             "DS_MERCHANT_TERMINAL": self.terminal,
@@ -153,7 +153,7 @@ class RedsysProvider(BasicProvider):
             "DS_MERCHANT_AMOUNT": cents,
             "DS_MERCHANT_ORDER": order_number,
             "DS_MERCHANT_MERCHANTCODE": self.merchant_code,
-            "DS_MERCHANT_DIRECTPAYMENT": self.ds_merchant_directpayment,
+            "DS_MERCHANT_DIRECTPAYMENT": self.direct_payment,
             "DS_MERCHANT_CURRENCY": self.currency,
             "DS_MERCHANT_TRANSACTIONTYPE": '3',
             "DS_MERCHANT_TERMINAL": self.terminal,

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -78,7 +78,7 @@ class RedsysProvider(BasicProvider):
         self.terminal = kwargs.pop('terminal')
         self.shared_secret = kwargs.pop('shared_secret')
         self.currency = kwargs.pop('currency', '978')
-        self.direct_payment = kwargs.pop('direct_payment', 'TRUE').upper()
+        self.direct_payment = str(kwargs.pop('direct_payment', True)).upper()
 
         # Get provided endpoint base domain or REDSYS.pruebas env
         self.endpoint = urljoin(

--- a/payments_redsys/__init__.py
+++ b/payments_redsys/__init__.py
@@ -78,6 +78,7 @@ class RedsysProvider(BasicProvider):
         self.terminal = kwargs.pop('terminal')
         self.shared_secret = kwargs.pop('shared_secret')
         self.currency = kwargs.pop('currency', '978')
+        self.ds_merchant_directpayment = kwargs.pop('ds_merchant_directpayment', 'TRUE')
 
         # Get provided endpoint base domain or REDSYS.pruebas env
         self.endpoint = urljoin(
@@ -116,6 +117,7 @@ class RedsysProvider(BasicProvider):
             "DS_MERCHANT_AMOUNT": amount,
             "DS_MERCHANT_ORDER": order_number,
             "DS_MERCHANT_MERCHANTCODE": self.merchant_code,
+            "DS_MERCHANT_DIRECTPAYMENT": self.ds_merchant_directpayment,
             "DS_MERCHANT_CURRENCY": self.currency,
             "DS_MERCHANT_TRANSACTIONTYPE": '0',
             "DS_MERCHANT_TERMINAL": self.terminal,
@@ -151,6 +153,7 @@ class RedsysProvider(BasicProvider):
             "DS_MERCHANT_AMOUNT": cents,
             "DS_MERCHANT_ORDER": order_number,
             "DS_MERCHANT_MERCHANTCODE": self.merchant_code,
+            "DS_MERCHANT_DIRECTPAYMENT": self.ds_merchant_directpayment,
             "DS_MERCHANT_CURRENCY": self.currency,
             "DS_MERCHANT_TRANSACTIONTYPE": '3',
             "DS_MERCHANT_TERMINAL": self.terminal,

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     description='A django-payments backend for the Redsys payment gateway',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='0.4',
+    version='0.5',
     url='https://github.com/ajostergaard/django-payments-redsys',
     packages=PACKAGES,
     include_package_data=True,


### PR DESCRIPTION
This integrates the parameter `DS_MERCHANT_DIRECTPAYMENT` using the configuration parameter `direct_payment`.

See https://pagosonline.redsys.es/oneclick.html for more information (in spanish) about `direct_payment`.

Possible values `direct_payment`: `True` or `False` (default is `False`). The value should be a boolean.

Example settings:
```
PAYMENT_VARIANTS = {
    ...
    "redsys": (
        "payments_redsys.RedsysProvider",
        {
            "merchant_code": "XXXXXX",
            "terminal": "1",
            "currency": "978",
            "shared_secret": "XXXXXX",
            "direct_payment": True,  <--- activate direct payment
        },
    ),
    ....
```